### PR TITLE
Integrate GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Test
-        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme "sample-ci-project" -project "sample-ci-project.xcodeproj" -destination "${{ matrix.destination }}" clean test | xcpretty
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme "sample-ci-project" -project "sample-ci-project.xcodeproj" -destination "${{ matrix.destination }}" -enableCodeCoverage YES clean test | xcpretty
 
   code_cov:
     name: Upload to codecov.io

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,9 +3,7 @@ name: Branch push CI
 # Documentation with macOS virtual environment: 
 # https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
 
-on:
-  push
-  pull_request
+on: [push, pull_request]
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_11.3.app/Contents/Developer

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   test:
-    name: Test and upload codecov
+    name: Test and codecov upload
     runs-on: macos-latest
 
     strategy:
@@ -20,6 +20,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+
+      - name: Swiftlint
+        run: |
+          chmod +x ./scripts/install_swiftlint.sh
+          ./scripts/install_swiftlint.sh
+          swiftlint lint --config ./configs/swiftlint.yml --strict
 
       - name: Test
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme "sample-ci-project" -project "sample-ci-project.xcodeproj" -destination "${{ matrix.destination }}" -enableCodeCoverage YES clean test | xcpretty

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,8 +9,8 @@ env:
   DEVELOPER_DIR: /Applications/Xcode_11.3.app/Contents/Developer
 
 jobs:
-  build_and_test:
-    name: Build and Test
+  test:
+    name: Test and upload codecov
     runs-on: macos-latest
 
     strategy:
@@ -24,11 +24,5 @@ jobs:
       - name: Test
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme "sample-ci-project" -project "sample-ci-project.xcodeproj" -destination "${{ matrix.destination }}" -enableCodeCoverage YES clean test | xcpretty
 
-  code_cov:
-    name: Upload to codecov.io
-    runs-on: macos-latest
-    needs: build_and_test
-
-    steps:
       - name: Upload to codecov.io
         run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,16 +1,19 @@
 name: Branch push CI
 
-on: push
-
 # Documentation with macOS virtual environment: 
 # https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
+
+on:
+  push
+  pull_request
+
+env:
+  DEVELOPER_DIR: /Applications/Xcode_11.3.app/Contents/Developer
 
 jobs:
   build_and_test:
     name: Build and Test
     runs-on: macos-latest
-    strategy:
-      xcode: ['/Applications/Xcode_11.3.app/Contents/Developer']
 
     steps:
       - name: Checkout
@@ -21,8 +24,6 @@ jobs:
 
       - name: Build and test
         run: bundle exec fastlane test
-        env:
-          DEVELOPER_DIR: ${{ matrix.xcode }}
 
   code_cov:
     name: Upload to codecov.io

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,32 @@
+name: Branch push CI
+
+on: push
+
+# Documentation with macOS virtual environment: 
+# https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
+
+jobs:
+  build_and_test:
+    name: Build and Test
+    strategy:
+      xcode: ['/Applications/Xcode_11.3.app/Contents/Developer']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Bundle install
+        run: bundle install
+
+      - name: Build and test
+        run: bundle exec fastlane test
+        env:
+          DEVELOPER_DIR: ${{ matrix.xcode }}
+
+  code_cov:
+    name: Upload to codecov.io
+    needs: build_and_test
+
+    steps:
+      - name: Upload to codecov.io
+        run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,16 +12,17 @@ jobs:
   build_and_test:
     name: Build and Test
     runs-on: macos-latest
+
     strategy:
       matrix:
-        destination: ["OS=13.1,name=iPhone 11 Pro"]
+        destination: ["name=iPhone 11"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v1
 
       - name: Test
-        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "sample-ci-project.xcodeproj" -scheme "sample-ci-project" -destination "${{ matrix.destination }}" clean test | xcpretty
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme "sample-ci-project" -project "sample-ci-project.xcodeproj" -destination "${{ matrix.destination }}" clean test | xcpretty
 
   code_cov:
     name: Upload to codecov.io

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,6 +8,7 @@ on: push
 jobs:
   build_and_test:
     name: Build and Test
+    runs-on: macos-latest
     strategy:
       xcode: ['/Applications/Xcode_11.3.app/Contents/Developer']
 
@@ -25,6 +26,7 @@ jobs:
 
   code_cov:
     name: Upload to codecov.io
+    runs-on: macos-latest
     needs: build_and_test
 
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,5 +30,7 @@ jobs:
       - name: Test
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme "sample-ci-project" -project "sample-ci-project.xcodeproj" -destination "${{ matrix.destination }}" -enableCodeCoverage YES clean test | xcpretty
 
-      - name: Upload to codecov.io
-        run: bash <(curl -s https://codecov.io/bash)
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,16 +12,16 @@ jobs:
   build_and_test:
     name: Build and Test
     runs-on: macos-latest
+    strategy:
+      matrix:
+        destination: ["OS=13.1,name=iPhone 11 Pro"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Bundle install
-        run: bundle install
-
-      - name: Build and test
-        run: bundle exec fastlane test
+      - name: Test
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "sample-ci-project.xcodeproj" -scheme "sample-ci-project" -destination "${{ matrix.destination }}" clean test | xcpretty
 
   code_cov:
     name: Upload to codecov.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Branch push CI
+name: CI
 
 # Documentation with macOS virtual environment: 
 # https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ script:
   - swiftlint lint --config ./configs/swiftlint.yml --strict
   - bundle exec fastlane test
 
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+# after_success:
+#   - bash <(curl -s https://codecov.io/bash)
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ script:
   - swiftlint lint --config ./configs/swiftlint.yml --strict
   - bundle exec fastlane test
 
-# after_success:
-#   - bash <(curl -s https://codecov.io/bash)
-
 notifications:
   email:
     recipients:
@@ -25,4 +22,3 @@ notifications:
 
 git:
   depth: 1
-

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,7 +7,7 @@ platform :ios do
 			scheme: "sample-ci-project",
 			project: "sample-ci-project.xcodeproj",
 			clean: true,
-			code_coverage: true,
+			code_coverage: false,
 			skip_slack: true,
 			sdk: "iphonesimulator"
 			)


### PR DESCRIPTION
### Background
Wanted to check the `Github Actions` in action 😄.
Decided to go with `xcodebuild` instead of `fastlane` for next reasons:
1. It's faster 🤷‍♂️
2. Fastlane is a powerful tool, but this project requires only one action. Not worth it.
3. Wanted to have an example of `fastlane` and `xcodebuild` in the same repo.

### What has been done
1. Integrated Github actions by adding a  `Branch push CI` workflow. The workflow includes: checkout, swiftlint, test using `xcodebuild`, upload to `codecov`
2. Moved the uploading of code coverage from `travis` to `github actions`
3. Disabled code coverage in `Fastlane` test action

### How to test
1. Check that CI is passing
2. Code coverage should be reported