### PR TITLE
Add status badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# sample-ci-project
-Tha sample project on which travis CI will be configured
+[![Build Status](https://github.com/lexorus/sample-ci-project/workflows/CI/badge.svg)](https://github.com/lexorus/sample-ci-project/actions)
+[![Build Status](https://travis-ci.org/lexorus/sample-ci-project.svg?branch=master)](https://travis-ci.org/lexorus/sample-ci-project)
+[![codecov](https://codecov.io/gh/lexorus/sample-ci-project/branch/master/graph/badge.svg)](https://codecov.io/gh/lexorus/sample-ci-project)
+
+# Sample CI project
+This is a playground projct to play with some continues integration platforms and tools.


### PR DESCRIPTION
### Background
The status of the repository should be visible in its `README.md`.

### What has been done
1. Add status badges to README.md

### How to test
1. Go to the main page of the repo
2. Change the branch to `feature/add-status-badges-to-readme`
3. Check that badges are visible and reflect the current status