### PR TITLE
Integrate circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+version: 2.1
+
+defaults: &defaults
+  macos:
+    xcode: 11.3.1
+  parallelism: 1
+
+jobs:
+  build:
+    <<: *defaults
+    steps:
+      - checkout
+
+      - run:
+          name: Swiftlint
+          command: |
+            chmod +x ./scripts/install_swiftlint.sh
+            ./scripts/install_swiftlint.sh
+            swiftlint lint --config ./configs/swiftlint.yml --strict
+
+      - run:
+          name: Set Ruby Version
+          command: echo "ruby-2.4" > ~/.ruby-version
+
+      - run:
+          name: Install ruby dependencies
+          command: bundle check || bundle install
+          environment:
+              BUNDLE_JOBS: 4
+              BUNDLE_RETRY: 3
+
+      - run:
+          name: Test
+          command: bundle exec fastlane test
+
+      - store_test_results:
+          path: test_output
+
+      - store_artifacts:
+          path: test_output
+          destination: scan-output


### PR DESCRIPTION
**This PR will be closed**

### Background
So, wanted to play with circle ci. Turns out that `circle ci`s free plan includes `windows` and `linux` machines, but not `macOS` ([link](https://circleci.com/pricing/)). They have an [option for `Open Source`](https://circleci.com/open-source/), you can write an email with an explanation and they may approve. Maybe will try later. Or they may add `macOS` for free plan, as the [prising page](https://circleci.com/pricing/) suggests: `Coming Soon`.

### What has been done
1. Enable the project on [circle ci](https://app.circleci.com/pipelines/github/lexorus/sample-ci-project)
2. Configured `.circleci/config.yml`

### How to test
The `macOS VM` will not start for the free plan. The only thing that may be tested, is the validity of the config.

**Why open PR?** you may ask if it will be closed anyway. Mostly for history. I want to have the `.circleci/config.yml` somewhere, and not on a stale branch.
